### PR TITLE
Menu hook finish true (but empty) if no access

### DIFF
--- a/iris_core/modules/core/menu/menu.js
+++ b/iris_core/modules/core/menu/menu.js
@@ -111,7 +111,7 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
     }
 
   })
-
+  
   if (menuLinks.length) {
 
     // Menu ready, check access
@@ -128,7 +128,7 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
 
       }, function (noaccess) {
 
-        thisHook.finish(false, noaccess);
+        thisHook.finish(true, "");
 
       })
 


### PR DESCRIPTION
Fixed bug where if you weren't allowed to see the admin menu it timed out as the hook was finished with false rather than true.